### PR TITLE
Fix/support change observable type when reassignment

### DIFF
--- a/src/core/ObservableArray.js
+++ b/src/core/ObservableArray.js
@@ -5,8 +5,17 @@ class ObservableArray extends ObservableInterface {
   constructor(array, { name = '' } = {}) {
     super('[array] ' + name, false);
     this._name = name;
-    this._initializeArray(array);
+    this.array = ObservableArray._initializeArray(array, this._getMethodList(), this._name);
   }
+
+  _getMethodList = () => {
+    return {
+      push: this.push,
+      pop: this.pop,
+      filter: this.filter,
+      map: this.map,
+    };
+  };
 
   get = () => {
     this._registerAutorun(this);
@@ -15,7 +24,7 @@ class ObservableArray extends ObservableInterface {
 
   set = (array) => {
     // todo: use getObservableWithCorrectType
-    this._initializeArray(array);
+    this.array = ObservableArray._initializeArray(array, this._getMethodList(), this._name);
     this._triggerAutorun();
   };
 
@@ -60,27 +69,27 @@ class ObservableArray extends ObservableInterface {
     return new ObservableArray(plainArr.map(fn), { name }).array;
   };
 
-  // todo: change to pure function
-  _initializeArray(plainArray = []) {
-    this.array = {
+  // (√) todo: change to pure function
+  static _initializeArray(plainArray = [], arrayMethods, name) {
+    const array = {
       length: 0,
-      push: this.push,
-      pop: this.pop,
-      filter: this.filter,
-      map: this.map,
     };
 
-    Object.keys(this.array).forEach(key => {
-      Object.defineProperty(this.array, key, { enumerable: false });
+    Object.keys(arrayMethods).forEach(key => {
+      array[key] = arrayMethods[key];
+    });
+
+    Object.keys(array).forEach(key => {
+      Object.defineProperty(array, key, { enumerable: false });
     });
 
     if (plainArray && plainArray.length) {
-      this.array.length = plainArray.length;
+      array.length = plainArray.length;
       for (let i = 0; i < plainArray.length; i++) {
         const value = plainArray[i];
-        const fullyQualifiedName = this._name + '#' + i + '#' + Math.random().toString().substr(2, 4);
+        const fullyQualifiedName = !name ? undefined : name + '#' + i + '#' + Math.random().toString().substr(2, 4);
         const observableProp = getObservableWithCorrectType(value, fullyQualifiedName);
-        Object.defineProperty(this.array, i, {
+        Object.defineProperty(array, i, {
           enumerable: true,
           configurable: true,
           get() {
@@ -92,6 +101,8 @@ class ObservableArray extends ObservableInterface {
         });
       }
     }
+
+    return array;
   }
 }
 

--- a/src/core/ObservableArray.js
+++ b/src/core/ObservableArray.js
@@ -14,6 +14,7 @@ class ObservableArray extends ObservableInterface {
   };
 
   set = (array) => {
+    // todo: use getObservableWithCorrectType
     this._initializeArray(array);
     this._triggerAutorun();
   };
@@ -46,15 +47,20 @@ class ObservableArray extends ObservableInterface {
   filter = (fn) => {
     const plainArr = Array.from(this.array);
     const name = `filtered#${Math.random().toString().substr(2, 4)}`;
+
+    // todo: use _initializeArray here
     return new ObservableArray(plainArr.filter(fn), { name }).array;
   };
 
   map = (fn) => {
     const plainArr = Array.from(this.array);
     const name = `mapped#${Math.random().toString().substr(2, 4)}`;
+
+    // todo: use _initializeArray here
     return new ObservableArray(plainArr.map(fn), { name }).array;
   };
 
+  // todo: change to pure function
   _initializeArray(plainArray = []) {
     this.array = {
       length: 0,

--- a/src/core/ObservableArray.js
+++ b/src/core/ObservableArray.js
@@ -13,9 +13,8 @@ class ObservableArray extends ObservableInterface {
     return this.array;
   };
 
-  set = (array) => {
-    // todo: use getObservableWithCorrectType
-    this._initializeArray(array);
+  set = (newArray) => {
+    this.array = getObservableWithCorrectType(newArray, this._name).get();
     this._triggerAutorun();
   };
 

--- a/src/core/ObservableArray.js
+++ b/src/core/ObservableArray.js
@@ -48,7 +48,8 @@ class ObservableArray extends ObservableInterface {
     const plainArr = Array.from(this.array);
     const name = `filtered#${Math.random().toString().substr(2, 4)}`;
 
-    // todo: use _initializeArray here
+    /** We must create a new observable array object so the `this` is bound correctly to the new one;
+     * This doesn't lead to over-subscribing issue because we don't access the new array via getter*/
     return new ObservableArray(plainArr.filter(fn), { name }).array;
   };
 
@@ -56,11 +57,9 @@ class ObservableArray extends ObservableInterface {
     const plainArr = Array.from(this.array);
     const name = `mapped#${Math.random().toString().substr(2, 4)}`;
 
-    // todo: use _initializeArray here
     return new ObservableArray(plainArr.map(fn), { name }).array;
   };
 
-  // todo: change to pure function
   _initializeArray(plainArray = []) {
     this.array = {
       length: 0,

--- a/src/core/ObservableArray.js
+++ b/src/core/ObservableArray.js
@@ -5,17 +5,8 @@ class ObservableArray extends ObservableInterface {
   constructor(array, { name = '' } = {}) {
     super('[array] ' + name, false);
     this._name = name;
-    this.array = ObservableArray._initializeArray(array, this._getMethodList(), this._name);
+    this._initializeArray(array);
   }
-
-  _getMethodList = () => {
-    return {
-      push: this.push,
-      pop: this.pop,
-      filter: this.filter,
-      map: this.map,
-    };
-  };
 
   get = () => {
     this._registerAutorun(this);
@@ -24,7 +15,7 @@ class ObservableArray extends ObservableInterface {
 
   set = (array) => {
     // todo: use getObservableWithCorrectType
-    this.array = ObservableArray._initializeArray(array, this._getMethodList(), this._name);
+    this._initializeArray(array);
     this._triggerAutorun();
   };
 
@@ -69,27 +60,27 @@ class ObservableArray extends ObservableInterface {
     return new ObservableArray(plainArr.map(fn), { name }).array;
   };
 
-  // (√) todo: change to pure function
-  static _initializeArray(plainArray = [], arrayMethods, name) {
-    const array = {
+  // todo: change to pure function
+  _initializeArray(plainArray = []) {
+    this.array = {
       length: 0,
+      push: this.push,
+      pop: this.pop,
+      filter: this.filter,
+      map: this.map,
     };
 
-    Object.keys(arrayMethods).forEach(key => {
-      array[key] = arrayMethods[key];
-    });
-
-    Object.keys(array).forEach(key => {
-      Object.defineProperty(array, key, { enumerable: false });
+    Object.keys(this.array).forEach(key => {
+      Object.defineProperty(this.array, key, { enumerable: false });
     });
 
     if (plainArray && plainArray.length) {
-      array.length = plainArray.length;
+      this.array.length = plainArray.length;
       for (let i = 0; i < plainArray.length; i++) {
         const value = plainArray[i];
-        const fullyQualifiedName = !name ? undefined : name + '#' + i + '#' + Math.random().toString().substr(2, 4);
+        const fullyQualifiedName = this._name + '#' + i + '#' + Math.random().toString().substr(2, 4);
         const observableProp = getObservableWithCorrectType(value, fullyQualifiedName);
-        Object.defineProperty(array, i, {
+        Object.defineProperty(this.array, i, {
           enumerable: true,
           configurable: true,
           get() {
@@ -101,8 +92,6 @@ class ObservableArray extends ObservableInterface {
         });
       }
     }
-
-    return array;
   }
 }
 

--- a/src/core/ObservableObject.js
+++ b/src/core/ObservableObject.js
@@ -14,8 +14,7 @@ class ObservableObject extends ObservableInterface {
   };
 
   set = (newObject) => {
-    // todo: use getObservableWithCorrectType
-    this._initializeObject(newObject);
+    this.object = getObservableWithCorrectType(newObject, this._name).get();
     this._triggerAutorun();
   };
 

--- a/src/core/ObservableObject.js
+++ b/src/core/ObservableObject.js
@@ -14,10 +14,12 @@ class ObservableObject extends ObservableInterface {
   };
 
   set = (newObject) => {
+    // todo: use getObservableWithCorrectType
     this._initializeObject(newObject);
     this._triggerAutorun();
   };
 
+  // todo: change to pure function
   _initializeObject(plainObject = {}) {
     const keys = Object.keys(plainObject);
     const object = {};

--- a/src/core/ObservableObject.js
+++ b/src/core/ObservableObject.js
@@ -21,6 +21,8 @@ class ObservableObject extends ObservableInterface {
 
   // todo: change to pure function
   _initializeObject(plainObject = {}) {
+    if (plainObject === null) plainObject = {};
+
     const keys = Object.keys(plainObject);
     const object = {};
     for (let i = 0; i < keys.length; i++) {

--- a/src/core/ObservableObject.js
+++ b/src/core/ObservableObject.js
@@ -5,7 +5,7 @@ class ObservableObject extends ObservableInterface {
   constructor(object, { name = '' } = {}) {
     super('[object] ' + name, false);
     this._name = name;
-    this.object = ObservableObject._initializeObject(object, this._name);
+    this._initializeObject(object);
   }
 
   get = () => {
@@ -13,14 +13,14 @@ class ObservableObject extends ObservableInterface {
     return this.object;
   };
 
-  set = (newProperty) => {
+  set = (newObject) => {
     // todo: use getObservableWithCorrectType
-    this.object = ObservableObject._initializeObject(newProperty, this._name);
+    this._initializeObject(newObject);
     this._triggerAutorun();
   };
 
-  // (√) todo: change to pure function
-  static _initializeObject(plainObject = {}, name) {
+  // todo: change to pure function
+  _initializeObject(plainObject = {}) {
     if (plainObject === null) plainObject = {};
 
     const keys = Object.keys(plainObject);
@@ -28,7 +28,7 @@ class ObservableObject extends ObservableInterface {
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
       const value = plainObject[key];
-      const fullyQualifiedName = !name ? undefined : name + '#' + key + '#' + Math.random().toString().substr(2, 4);
+      const fullyQualifiedName = this._name + '#' + key + '#' + Math.random().toString().substr(2, 4);
       const observableProp = getObservableWithCorrectType(value, fullyQualifiedName);
       Object.defineProperty(object, key, {
         enumerable: true,
@@ -41,8 +41,7 @@ class ObservableObject extends ObservableInterface {
         },
       });
     }
-
-    return object;
+    this.object = object;
   }
 }
 

--- a/src/core/ObservableObject.js
+++ b/src/core/ObservableObject.js
@@ -5,7 +5,7 @@ class ObservableObject extends ObservableInterface {
   constructor(object, { name = '' } = {}) {
     super('[object] ' + name, false);
     this._name = name;
-    this._initializeObject(object);
+    this.object = ObservableObject._initializeObject(object, this._name);
   }
 
   get = () => {
@@ -13,14 +13,14 @@ class ObservableObject extends ObservableInterface {
     return this.object;
   };
 
-  set = (newObject) => {
+  set = (newProperty) => {
     // todo: use getObservableWithCorrectType
-    this._initializeObject(newObject);
+    this.object = ObservableObject._initializeObject(newProperty, this._name);
     this._triggerAutorun();
   };
 
-  // todo: change to pure function
-  _initializeObject(plainObject = {}) {
+  // (√) todo: change to pure function
+  static _initializeObject(plainObject = {}, name) {
     if (plainObject === null) plainObject = {};
 
     const keys = Object.keys(plainObject);
@@ -28,7 +28,7 @@ class ObservableObject extends ObservableInterface {
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
       const value = plainObject[key];
-      const fullyQualifiedName = this._name + '#' + key + '#' + Math.random().toString().substr(2, 4);
+      const fullyQualifiedName = !name ? undefined : name + '#' + key + '#' + Math.random().toString().substr(2, 4);
       const observableProp = getObservableWithCorrectType(value, fullyQualifiedName);
       Object.defineProperty(object, key, {
         enumerable: true,
@@ -41,7 +41,8 @@ class ObservableObject extends ObservableInterface {
         },
       });
     }
-    this.object = object;
+
+    return object;
   }
 }
 

--- a/src/core/ObservableObject.js
+++ b/src/core/ObservableObject.js
@@ -19,7 +19,6 @@ class ObservableObject extends ObservableInterface {
     this._triggerAutorun();
   };
 
-  // todo: change to pure function
   _initializeObject(plainObject = {}) {
     if (plainObject === null) plainObject = {};
 

--- a/src/core/ObservableObject.js
+++ b/src/core/ObservableObject.js
@@ -19,7 +19,13 @@ class ObservableObject extends ObservableInterface {
   };
 
   _initializeObject(plainObject = {}) {
-    if (plainObject === null) plainObject = {};
+    /** null should never be passed into this function,
+     * but we keep this checking as a good practice of defensive programming
+     */
+    if (plainObject === null) {
+      this.object = getObservableWithCorrectType(null, this._name).get();
+      return;
+    }
 
     const keys = Object.keys(plainObject);
     const object = {};

--- a/src/core/ObservablePrimitive.js
+++ b/src/core/ObservablePrimitive.js
@@ -1,8 +1,10 @@
 import ObservableInterface from './ObservableInterface';
+import { getObservableWithCorrectType } from '../utils/observableTypeHelper';
 
 class ObservablePrimitive extends ObservableInterface {
   constructor(value, { name = '' } = {}) {
     super('[primitive] ' + name, false);
+    this._name = name;
     this.value = value;
   }
 
@@ -12,8 +14,7 @@ class ObservablePrimitive extends ObservableInterface {
   };
 
   set = (newValue) => {
-    // todo: use getObservableWithCorrectType
-    this.value = newValue;
+    this.value = getObservableWithCorrectType(newValue, this._name).get();
     this._triggerAutorun();
   };
 }

--- a/src/core/ObservablePrimitive.js
+++ b/src/core/ObservablePrimitive.js
@@ -12,6 +12,7 @@ class ObservablePrimitive extends ObservableInterface {
   };
 
   set = (newValue) => {
+    // todo: use getObservableWithCorrectType
     this.value = newValue;
     this._triggerAutorun();
   };

--- a/src/utils/observableTypeHelper.js
+++ b/src/utils/observableTypeHelper.js
@@ -3,6 +3,9 @@ import ObservableArray from '../core/ObservableArray';
 import ObservableObject from '../core/ObservableObject';
 
 export function getObservableWithCorrectType(value, name = '') {
+  /** null is of type object, but we consider it a primitive so as to preserve its value,
+   * if we consider `null` an object, then ObservableObject will confuse it with empty object {}
+   * */
   if (value === null) {
     return new ObservablePrimitive(value, { name });
   } else if (Array.isArray(value)) {

--- a/src/utils/observableTypeHelper.js
+++ b/src/utils/observableTypeHelper.js
@@ -3,7 +3,9 @@ import ObservableArray from '../core/ObservableArray';
 import ObservableObject from '../core/ObservableObject';
 
 export function getObservableWithCorrectType(value, name = '') {
-  if (Array.isArray(value)) {
+  if (value === null) {
+    return new ObservablePrimitive(value, { name });
+  } else if (Array.isArray(value)) {
     return new ObservableArray(value, { name });
   } else if (typeof value === 'object') {
     return new ObservableObject(value, { name });

--- a/tests/autorun.test.js
+++ b/tests/autorun.test.js
@@ -241,7 +241,7 @@ describe('autorun gets triggered properly', () => {
         name: 'Mary',
         projects: expect.anything(),
       }));
-      expect(Array.from(mockFn.mock.calls[mockFn.mock.calls.length - 1][3])).toEqual(employee.projects);
+      expect(Array.from(getArgsInLastCall(mockFn)[3])).toEqual(employee.projects);
     });
 
     it('triggered if mutate an array property in the object', () => {
@@ -253,7 +253,7 @@ describe('autorun gets triggered properly', () => {
         ...employee,
         projects: expect.anything(),
       }));
-      expect(Array.from(mockFn.mock.calls[mockFn.mock.calls.length - 1][3])).toEqual([...employee.projects, 'projD']);
+      expect(Array.from(getArgsInLastCall(mockFn)[3])).toEqual([...employee.projects, 'projD']);
     });
 
     it('triggered if mutate an object property in the object', () => {

--- a/tests/autorun.test.js
+++ b/tests/autorun.test.js
@@ -1,6 +1,7 @@
 import Invoice from '../tests/fixture/Invoice';
 import Person from '../tests/fixture/Person';
 import TaskList from '../tests/fixture/TaskList';
+import { getArgsInLastCall } from './helpers/mockFunctionHelper';
 import { autorun } from '../src/core';
 import observable from '../src/core/observable';
 
@@ -141,10 +142,6 @@ describe('autorun gets triggered properly', () => {
       mockFn = jest.fn();
     });
 
-    function getArgInLastCall(mockFn) {
-      return Array.from(mockFn.mock.calls[mockFn.mock.calls.length - 1][0]);
-    }
-
     it('triggered when re-assign the array itself', () => {
       autorun(() => mockFn(taskList.tasks));
       expect(mockFn).toHaveBeenCalledTimes(1);
@@ -159,7 +156,7 @@ describe('autorun gets triggered properly', () => {
       autorun(() => mockFn(taskList.tasks.map(i => i)));
       expect(mockFn).toHaveBeenCalledTimes(1);
       taskList.tasks[0] = { title: 'go swimming' };
-      expect(getArgInLastCall(mockFn)).toEqual([{ title: 'go swimming' }, ITEM_2]);
+      expect(Array.from(getArgsInLastCall(mockFn)[0])).toEqual([{ title: 'go swimming' }, ITEM_2]);
       expect(mockFn).toHaveBeenCalledTimes(2);
     });
 
@@ -170,7 +167,7 @@ describe('autorun gets triggered properly', () => {
       autorun(() => mockFn(taskList.tasks.map(i => i)));
       expect(mockFn).toHaveBeenCalledTimes(1);
       taskList.tasks[0].title = 'go swimming';
-      expect(getArgInLastCall(mockFn)).toEqual([{ title: 'go swimming' }, ITEM_2]);
+      expect(Array.from(getArgsInLastCall(mockFn)[0])).toEqual([{ title: 'go swimming' }, ITEM_2]);
       expect(mockFn).toHaveBeenCalledTimes(2);
     });
 
@@ -178,7 +175,7 @@ describe('autorun gets triggered properly', () => {
       autorun(() => mockFn(taskList.tasks));
       taskList.tasks.push(ITEM_1);
 
-      expect(getArgInLastCall(mockFn)).toEqual([ITEM_1]);
+      expect(Array.from(getArgsInLastCall(mockFn)[0])).toEqual([ITEM_1]);
       expect(mockFn).toHaveBeenCalledTimes(2);
     });
 
@@ -187,15 +184,15 @@ describe('autorun gets triggered properly', () => {
       taskList.tasks.push(ITEM_2);
 
       autorun(() => mockFn(taskList.tasks));
-      expect(getArgInLastCall(mockFn)).toEqual([ITEM_1, ITEM_2]);
+      expect(Array.from(getArgsInLastCall(mockFn)[0])).toEqual([ITEM_1, ITEM_2]);
 
       const popped1 = taskList.tasks.pop();
       expect(popped1).toEqual(ITEM_2);
-      expect(getArgInLastCall(mockFn)).toEqual([ITEM_1]);
+      expect(Array.from(getArgsInLastCall(mockFn)[0])).toEqual([ITEM_1]);
 
       const popped2 = taskList.tasks.pop();
       expect(popped2).toEqual(ITEM_1);
-      expect(getArgInLastCall(mockFn)).toEqual([]);
+      expect(Array.from(getArgsInLastCall(mockFn)[0])).toEqual([]);
 
       expect(mockFn).toHaveBeenCalledTimes(3);
     });

--- a/tests/autorun.test.js
+++ b/tests/autorun.test.js
@@ -159,6 +159,7 @@ describe('autorun gets triggered properly', () => {
       autorun(() => mockFn(taskList.tasks.map(i => i)));
       expect(mockFn).toHaveBeenCalledTimes(1);
       taskList.tasks[0] = { title: 'go swimming' };
+      expect(getArgInLastCall(mockFn)).toEqual([{ title: 'go swimming' }, ITEM_2]);
       expect(mockFn).toHaveBeenCalledTimes(2);
     });
 
@@ -169,6 +170,7 @@ describe('autorun gets triggered properly', () => {
       autorun(() => mockFn(taskList.tasks.map(i => i)));
       expect(mockFn).toHaveBeenCalledTimes(1);
       taskList.tasks[0].title = 'go swimming';
+      expect(getArgInLastCall(mockFn)).toEqual([{ title: 'go swimming' }, ITEM_2]);
       expect(mockFn).toHaveBeenCalledTimes(2);
     });
 

--- a/tests/helpers/mockFunctionHelper.js
+++ b/tests/helpers/mockFunctionHelper.js
@@ -1,0 +1,4 @@
+export function getArgsInLastCall(mockFn) {
+  const { calls } = mockFn.mock;
+  return calls[calls.length - 1];
+}

--- a/tests/observable.test.js
+++ b/tests/observable.test.js
@@ -206,10 +206,10 @@ describe('@observable remains as an observable property after reassignment / ope
     tester.primitive = 2;
     expect(mockFn).toHaveBeenLastCalledWith(2);
 
-    tester.primitive = undefined;
+    tester.primitive = undefined; // fixme: unsure what to expect
     expect(mockFn).toHaveBeenLastCalledWith(undefined);
 
-    tester.primitive = null;
+    tester.primitive = null; // fixme: unsure what to expect
     expect(getArgsInLastCall(mockFn)[0]).toEqual({});
 
     tester.primitive = [100, 101];

--- a/tests/observable.test.js
+++ b/tests/observable.test.js
@@ -1,5 +1,6 @@
 import { observable } from '../src/core';
 import autorun from '../src/core/autorun';
+import { getArgsInLastCall } from './helpers/mockFunctionHelper';
 
 describe('@observable is initialized correctly', () => {
   describe('works for primitive values', () => {
@@ -191,14 +192,6 @@ describe('@observable remains as an observable property after reassignment / ope
     @observable object = { 'a': 1, 'b': 2 };
   }
 
-  function getGetterToString(instance, name) {
-    return Object.getOwnPropertyDescriptor(instance, name).get.toString();
-  }
-
-  function getArgInLastCall(mockFn) {
-    return Array.from(mockFn.mock.calls[mockFn.mock.calls.length - 1][0]);
-  }
-
   let tester;
   let mockFn;
   beforeEach(() => {
@@ -217,10 +210,10 @@ describe('@observable remains as an observable property after reassignment / ope
     expect(mockFn).toHaveBeenLastCalledWith(undefined);
 
     tester.primitive = null;
-    expect(getArgInLastCall(mockFn)).toEqual({});
+    expect(getArgsInLastCall(mockFn)[0]).toEqual({});
 
     tester.primitive = [100, 101];
-    expect(getArgInLastCall(mockFn)).toEqual([100, 101]);
+    expect(getArgsInLastCall(mockFn)[0]).toEqual([100, 101]);
 
     tester.primitive = tester.array;
     expect(mockFn).toHaveBeenLastCalledWith(tester.array);
@@ -241,6 +234,10 @@ describe('@observable remains as an observable property after reassignment / ope
 describe('@observable creates non-observable with observable properties within', () => {
   class Tester {
     @observable array = [1, 2, 3, 4];
+  }
+
+  function getArgInLastCall(mockFn) {
+    return Array.from(mockFn.mock.calls[mockFn.mock.calls.length - 1][0]);
   }
 
   let tester;

--- a/tests/observable.test.js
+++ b/tests/observable.test.js
@@ -101,7 +101,7 @@ describe('@observable is initialized correctly', () => {
       expect(tester1.foo).toBe(undefined);
 
       const tester2 = new Tester(null);
-      expect(tester2.foo).toEqual({});
+      expect(tester2.foo).toEqual(null);
     });
 
     it('works when observable is initialized via assignment', () => {
@@ -112,7 +112,7 @@ describe('@observable is initialized correctly', () => {
 
       const tester = new Tester();
       expect(tester.foo).toBe(undefined);
-      expect(tester.bar).toEqual({});
+      expect(tester.bar).toEqual(null);
     });
   });
 });
@@ -206,14 +206,14 @@ describe('@observable remains as an observable property after reassignment / ope
     tester.primitive = 2;
     expect(mockFn).toHaveBeenLastCalledWith(2);
 
-    tester.primitive = undefined; // fixme: unsure what to expect
+    tester.primitive = undefined;
     expect(mockFn).toHaveBeenLastCalledWith(undefined);
 
-    tester.primitive = null; // fixme: unsure what to expect
-    expect(getArgsInLastCall(mockFn)[0]).toEqual({});
+    tester.primitive = null;
+    expect(getArgsInLastCall(mockFn)[0]).toEqual(null);
 
     tester.primitive = [100, 101];
-    expect(getArgsInLastCall(mockFn)[0]).toEqual([100, 101]);
+    expect(Array.from(getArgsInLastCall(mockFn)[0])).toEqual([100, 101]);
 
     tester.primitive = tester.array;
     expect(mockFn).toHaveBeenLastCalledWith(tester.array);

--- a/tests/observable.test.js
+++ b/tests/observable.test.js
@@ -1,4 +1,5 @@
 import { observable } from '../src/core';
+import autorun from '../src/core/autorun';
 
 describe('@observable is initialized correctly', () => {
   describe('works for primitive values', () => {
@@ -84,6 +85,35 @@ describe('@observable is initialized correctly', () => {
       expect(tester.employee).toEqual(employee);
     });
   });
+
+  describe('works for null and undefined', () => {
+    it('works when observable is initialized via constructor', () => {
+      class Tester {
+        constructor(foo) {
+          this.foo = foo;
+        }
+
+        @observable foo;
+      }
+
+      const tester1 = new Tester(undefined);
+      expect(tester1.foo).toBe(undefined);
+
+      const tester2 = new Tester(null);
+      expect(tester2.foo).toEqual({});
+    });
+
+    it('works when observable is initialized via assignment', () => {
+      class Tester {
+        @observable foo = undefined;
+        @observable bar = null;
+      }
+
+      const tester = new Tester();
+      expect(tester.foo).toBe(undefined);
+      expect(tester.bar).toEqual({});
+    });
+  });
 });
 
 describe('@observable decorates class property in an instance-specific manner', () => {
@@ -140,13 +170,135 @@ describe('@observable decorates class property in an instance-specific manner', 
   });
 });
 
-describe('@observable remains as an observable property after operations', () => {
-  it('is still observable after reassignment - primitive values');
-  it('is still observable after reassignment - array');
-  it('is still observable after reassignment - object itself');
-  it('is still observable after reassignment - object properties');
-  it('is still observable after array pushing');
-  it('is still observable after array popping');
-  it('is still observable after array mapping');
-  it('is still observable after array filtering');
+describe('@observable remains as an observable property after reassignment / operations', () => {
+  /**
+   * There are three types of observable:
+   *   primitive
+   *   array
+   *   object
+   *
+   * Reassignment could be:
+   *   reassign with a new property of the same type
+   *   reassign with a new property of different type
+   *   reassign with null
+   *   reassign with undefined
+   *   reassign with another observable
+   * */
+
+  class Tester {
+    @observable primitive = 1;
+    @observable array = [1, 2, 3, 4];
+    @observable object = { 'a': 1, 'b': 2 };
+  }
+
+  function getGetterToString(instance, name) {
+    return Object.getOwnPropertyDescriptor(instance, name).get.toString();
+  }
+
+  function getArgInLastCall(mockFn) {
+    return Array.from(mockFn.mock.calls[mockFn.mock.calls.length - 1][0]);
+  }
+
+  let tester;
+  let mockFn;
+  beforeEach(() => {
+    tester = new Tester();
+    mockFn = jest.fn();
+  });
+
+  it('is still observable after reassignment - primitive values', () => {
+    autorun(() => mockFn(tester.primitive));
+    expect(mockFn).toHaveBeenCalledTimes(1);
+
+    tester.primitive = 2;
+    expect(mockFn).toHaveBeenLastCalledWith(2);
+
+    tester.primitive = undefined;
+    expect(mockFn).toHaveBeenLastCalledWith(undefined);
+
+    tester.primitive = null;
+    expect(getArgInLastCall(mockFn)).toEqual({});
+
+    tester.primitive = [100, 101];
+    expect(getArgInLastCall(mockFn)).toEqual([100, 101]);
+
+    tester.primitive = tester.array;
+    expect(mockFn).toHaveBeenLastCalledWith(tester.array);
+
+    expect(mockFn).toHaveBeenCalledTimes(6);
+  });
+
+  it('is still observable after reassignment - array', () => {
+  });
+
+  it('is still observable after reassignment - object itself', () => {
+  });
+
+  it('is still observable after array operations (internal mutation)', () => {
+  });
+});
+
+describe('@observable creates non-observable with observable properties within', () => {
+  class Tester {
+    @observable array = [1, 2, 3, 4];
+  }
+
+  let tester;
+  let mockFn;
+  beforeEach(() => {
+    tester = new Tester();
+    mockFn = jest.fn();
+  });
+
+  it('does not return an observable from array operations (mapping etc.)', () => {
+    let arrayMapped = tester.array.map(i => i * 3);
+    let arrayFiltered = tester.array.filter(i => i % 2 === 0);
+    let arrayMappedFiltered = tester.array.map(i => i * 3).filter(i => i % 2 === 0);
+    let arrayFilteredMapped = tester.array.filter(i => i % 2 === 0).map(i => i * 3);
+    autorun(() => mockFn(arrayMapped));
+    autorun(() => mockFn(arrayFiltered));
+    autorun(() => mockFn(arrayMappedFiltered));
+    autorun(() => mockFn(arrayFilteredMapped));
+    expect(mockFn).toHaveBeenCalledTimes(4);
+
+    // if a property is NOT an observable, then re-assigning it should NOT trigger autorun
+
+    arrayMapped = 'foo1';
+    arrayFiltered = 'foo2';
+    arrayMappedFiltered = 'foo3';
+    arrayFilteredMapped = 'foo4';
+
+    expect(mockFn).toHaveBeenCalledTimes(4);
+  });
+
+  it('contains observable items in the returned array from array operations (mapping etc.)', () => {
+    let arrayMapped = tester.array.map(i => i * 3);
+    let arrayFiltered = tester.array.filter(i => i % 2 === 0);
+    let arrayMappedFiltered = tester.array.map(i => i * 3).filter(i => i % 2 === 0);
+    let arrayFilteredMapped = tester.array.filter(i => i % 2 === 0).map(i => i * 3);
+    autorun(() => mockFn(Array.from(arrayMapped)));
+    autorun(() => mockFn(Array.from(arrayFiltered)));
+    autorun(() => mockFn(Array.from(arrayMappedFiltered)));
+    autorun(() => mockFn(Array.from(arrayFilteredMapped)));
+    expect(mockFn).toHaveBeenCalledTimes(4);
+
+    // if a property is an observable, then re-assigning it should trigger autorun
+
+    arrayMapped[0] = 'foo1';
+    expect(getArgInLastCall(mockFn)[0]).toBe('foo1');
+
+    arrayFiltered[0] = 'foo2';
+    expect(getArgInLastCall(mockFn)[0]).toBe('foo2');
+
+    arrayMappedFiltered[0] = 'foo3';
+    expect(getArgInLastCall(mockFn)[0]).toBe('foo3');
+
+    arrayFilteredMapped[0] = 'foo4';
+    expect(getArgInLastCall(mockFn)[0]).toBe('foo4');
+
+    expect(mockFn).toHaveBeenCalledTimes(8);
+  });
+});
+
+describe('@observable changes type accordingly after reassignment', () => {
 });


### PR DESCRIPTION
#### This PR majorly accomplishes the following:
1. Add tests for checking `@observable` is still an observable after reassignment (types could be the same or different)
2. Supports changing the *type of observable* properly when the property is reassigned

> Note: There are totally three types of observable: primitives, arrays, and objects.