### PR TITLE
Feature/dispose autorun

### DIFF
--- a/src/core/AutorunFunction.js
+++ b/src/core/AutorunFunction.js
@@ -3,17 +3,11 @@ import ObservableInterface from './ObservableInterface';
 export default class AutorunFunction {
   constructor(fn) {
     this._fn = fn;
-    Object.defineProperty(this, '_fn', {enumerable: false});
+    Object.defineProperty(this, '_fn', { enumerable: false });
   }
 
-  run() {
-    for (let i = 0; i < this.observables.length; i++) {
-      const o = this.observables[i];
-      const idx = o.autoruns.indexOf(this);
-      if (idx >= 0) {
-        o.autoruns.splice(idx, 1);
-      }
-    }
+  run = () => {
+    this.dispose();
 
     ObservableInterface.initializingAutorun = this;
     try {
@@ -21,11 +15,25 @@ export default class AutorunFunction {
     } finally {
       ObservableInterface.initializingAutorun = null;
     }
-  }
+  };
 
-  registeredBy(o) {
+  dispose = () => {
+    for (let i = 0; i < this.observables.length; i++) {
+      const o = this.observables[i];
+      const idx = o.autoruns.indexOf(this);
+      if (idx >= 0) {
+        o.autoruns.splice(idx, 1);
+      }
+    }
+  };
+
+  getDisposer = () => {
+    return this.dispose;
+  };
+
+  registeredBy = (o) => {
     this.observables.push(o);
-  }
+  };
 
   observables = [];
 }

--- a/src/core/autorun.js
+++ b/src/core/autorun.js
@@ -1,5 +1,7 @@
 import AutorunFunction from './AutorunFunction';
 
 export default function autorun(fn) {
-  new AutorunFunction(fn).run();
+  const autorunFn = new AutorunFunction(fn);
+  autorunFn.run();
+  return autorunFn.getDisposer();
 }

--- a/tests/autorun.test.js
+++ b/tests/autorun.test.js
@@ -318,3 +318,23 @@ describe('autorun gets triggered properly', () => {
 
   });
 });
+
+describe('autorun can be disposed properly', () => {
+  let mockFn;
+  let invoice;
+  beforeEach(() => {
+    mockFn = jest.fn();
+    invoice = new Invoice(10, 3);
+  });
+
+  it('should be disposed and does not run again', () => {
+    const disposer = autorun(() => mockFn(invoice.total));
+    expect(mockFn).toHaveBeenLastCalledWith(10 * 3);
+    invoice.price = 15;
+    expect(mockFn).toHaveBeenLastCalledWith(15 * 3);
+    expect(mockFn).toHaveBeenCalledTimes(2);
+    disposer();
+    invoice.price = 25;
+    expect(mockFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/autorun.test.js
+++ b/tests/autorun.test.js
@@ -335,6 +335,7 @@ describe('autorun can be disposed properly', () => {
     expect(mockFn).toHaveBeenCalledTimes(2);
     disposer();
     invoice.price = 25;
+    invoice.amount = 100;
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
#### This PR implements the dispose() method for `autorun`

Now `autorun(...)` will return a disposer, and calling the disposer will un-register the autorun function in all `@observable`s, so changes in those `@observable`s will no longer trigger that unregistered function.